### PR TITLE
Refactor GPU support to use KernelAbstractions backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpaceCharge"
 uuid = "886cafed-6ce3-46b8-9147-fe45a2210a4b"
 authors = ["Ningdong Wang <ndwang3@gmail.com>", "Eiad Hamwi <eh652@cornell.edu>", "Tianyu Huang <thuang23@u.rochester.edu>"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -5,17 +5,13 @@ version = "1.1.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 
 [compat]
 AbstractFFTs = "1.5"
-Adapt = "4.3"
 Atomix = "1.1"
-CUDA = "5.8"
 FFTW = "1.9"
 KernelAbstractions = "0.9"
 SpecialFunctions = "2.5"

--- a/benchmark/deposit_benchmark.jl
+++ b/benchmark/deposit_benchmark.jl
@@ -46,7 +46,7 @@ function compare_cpu_gpu_deposit(grid_size, n_particles)
         particles_q_gpu = CuArray(particles_q)
         
         # Create mesh on GPU
-        mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; array_type=CuArray)
+        mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; backend=CUDABackend())
         
         gpu_time = @belapsed begin
             deposit!($mesh_gpu, $particles_x_gpu, $particles_y_gpu, $particles_z_gpu, $particles_q_gpu)

--- a/benchmark/full_pipeline_benchmark.jl
+++ b/benchmark/full_pipeline_benchmark.jl
@@ -39,7 +39,7 @@ function compare_cpu_gpu_full_pipeline(grid_size, n_particles; total_charge=1.0e
         particles_y_gpu = CuArray(particles_y)
         particles_z_gpu = CuArray(particles_z)
         particles_q_gpu = CuArray(particles_q)
-        mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; array_type=CuArray, total_charge=total_charge)
+        mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; backend=CUDABackend(), total_charge=total_charge)
         gpu_time = @belapsed begin
             deposit!($mesh_gpu, $particles_x_gpu, $particles_y_gpu, $particles_z_gpu, $particles_q_gpu)
             solve!($mesh_gpu)

--- a/benchmark/full_pipeline_profile.jl
+++ b/benchmark/full_pipeline_profile.jl
@@ -45,7 +45,7 @@ function run_gpu_full_pipeline(grid_size, n_particles; total_charge=1.0e-9, sigm
     particles_y_gpu = CuArray(particles_y)
     particles_z_gpu = CuArray(particles_z)
     particles_q_gpu = CuArray(particles_q)
-    mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; array_type=CuArray, total_charge=total_charge)
+    mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; backend=CUDABackend(), total_charge=total_charge)
     deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)
     solve!(mesh_gpu)
     interpolate_field(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu)

--- a/benchmark/solve_benchmark.jl
+++ b/benchmark/solve_benchmark.jl
@@ -108,7 +108,7 @@ function compare_cpu_gpu_solve(grid_size, n_particles; total_charge=1.0e-9, sigm
         particles_y_gpu = CuArray(particles_y)
         particles_z_gpu = CuArray(particles_z)
         particles_q_gpu = CuArray(particles_q)
-        mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; array_type=CuArray, total_charge=total_charge)
+        mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; backend=CUDABackend(), total_charge=total_charge)
         deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)
         gpu_time = @belapsed begin
             solve!($mesh_gpu)

--- a/examples/gpu_usage.jl
+++ b/examples/gpu_usage.jl
@@ -1,7 +1,7 @@
 using SpaceCharge
 using CUDA
 
-# GPU usage example: single point charge, using array_type=CuArray
+# GPU usage example: single point charge, using backend=CUDABackend()
 
 # Define grid size
 grid_size = (64, 64, 64)
@@ -12,8 +12,8 @@ particles_y_gpu = CuArray([0.0])
 particles_z_gpu = CuArray([0.0])
 particles_q_gpu = CuArray([1.0e-9])
 
-# Create a Mesh3D object with automatic bounds on the GPU (array_type=CuArray)
-mesh_gpu = Mesh3D(grid_size, particles_x_gpu, particles_y_gpu, particles_z_gpu; array_type=CuArray)
+# Create a Mesh3D object with automatic bounds on the GPU (backend=CUDABackend())
+mesh_gpu = Mesh3D(grid_size, particles_x_gpu, particles_y_gpu, particles_z_gpu; backend=CUDABackend())
 
 # Deposit particle charges onto the grid (on GPU)
 deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)

--- a/examples/gpu_usage.jl
+++ b/examples/gpu_usage.jl
@@ -1,7 +1,8 @@
 using SpaceCharge
 using CUDA
 
-# GPU usage example: single point charge, using backend=CUDABackend()
+# GPU usage example: single point charge with CuArray particles
+# The mesh backend is automatically inferred from the particle arrays.
 
 # Define grid size
 grid_size = (64, 64, 64)
@@ -12,8 +13,8 @@ particles_y_gpu = CuArray([0.0])
 particles_z_gpu = CuArray([0.0])
 particles_q_gpu = CuArray([1.0e-9])
 
-# Create a Mesh3D object with automatic bounds on the GPU (backend=CUDABackend())
-mesh_gpu = Mesh3D(grid_size, particles_x_gpu, particles_y_gpu, particles_z_gpu; backend=CUDABackend())
+# Create a Mesh3D object — backend is inferred from particle arrays
+mesh_gpu = Mesh3D(grid_size, particles_x_gpu, particles_y_gpu, particles_z_gpu)
 
 # Deposit particle charges onto the grid (on GPU)
 deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)

--- a/src/SpaceCharge.jl
+++ b/src/SpaceCharge.jl
@@ -1,8 +1,6 @@
 module SpaceCharge
 
 using KernelAbstractions
-using Adapt
-using CUDA
 using FFTW
 
 include("utils.jl")

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -85,7 +85,7 @@ This is the recommended constructor as it eliminates the need for bounds checkin
 
 # Keyword Arguments
 - `T::Type{<:AbstractFloat} = Float64`: The floating-point type for the mesh data.
-- `backend = CPU()`: The KernelAbstractions backend to use (e.g., `CPU()` for CPU, `CUDABackend()` for GPU).
+- `backend = get_backend(particles_x)`: The KernelAbstractions backend to use. Defaults to the backend of the particle arrays.
 - `gamma::Real = 1.0`: Relativistic gamma factor of the beam.
 - `total_charge::Real = 0.0`: Total charge of the particle bunch.
 
@@ -98,7 +98,7 @@ function Mesh3D(
     particles_y,
     particles_z;
     T::Type{<:AbstractFloat}=Float64,
-    backend=CPU(),
+    backend=get_backend(particles_x),
     gamma::Real=1.0,
     total_charge::Real=0.0
 )

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1,4 +1,3 @@
-using Adapt
 using AbstractFFTs
 
 """
@@ -86,7 +85,7 @@ This is the recommended constructor as it eliminates the need for bounds checkin
 
 # Keyword Arguments
 - `T::Type{<:AbstractFloat} = Float64`: The floating-point type for the mesh data.
-- `array_type::Type{<:AbstractArray} = Array`: The array type to use for data storage (e.g., `Array` for CPU, `CuArray` for GPU).
+- `backend = CPU()`: The KernelAbstractions backend to use (e.g., `CPU()` for CPU, `CUDABackend()` for GPU).
 - `gamma::Real = 1.0`: Relativistic gamma factor of the beam.
 - `total_charge::Real = 0.0`: Total charge of the particle bunch.
 
@@ -99,7 +98,7 @@ function Mesh3D(
     particles_y,
     particles_z;
     T::Type{<:AbstractFloat}=Float64,
-    array_type::Type{<:AbstractArray}=Array,
+    backend=CPU(),
     gamma::Real=1.0,
     total_charge::Real=0.0
 )
@@ -157,18 +156,11 @@ function Mesh3D(
     cv_total_charge = T(total_charge)
 
     # --- Array Allocation ---
-    # Create arrays on the CPU first
-    rho_cpu = zeros(T, grid_size)
-    efield_cpu = zeros(T, (grid_size..., 3))
-
-    # Move arrays to the target device (e.g., GPU)
-    rho = adapt(array_type, rho_cpu)
-    efield = adapt(array_type, efield_cpu)
+    rho = KernelAbstractions.zeros(backend, T, grid_size...)
+    efield = KernelAbstractions.zeros(backend, T, grid_size..., 3)
 
     # --- Struct Instantiation ---
-    A = typeof(rho) # Get the concrete array type
-    B = typeof(efield)
-    return Mesh3D{T, A, B}(
+    return Mesh3D{T, typeof(rho), typeof(efield)}(
         grid_size,
         cv_min_bounds,
         cv_max_bounds,
@@ -194,7 +186,7 @@ Use the particle-based constructor instead for automatic bounds determination.
 
 # Keyword Arguments
 - `T::Type{<:AbstractFloat} = Float64`: The floating-point type for the mesh data.
-- `array_type::Type{<:AbstractArray} = Array`: The array type to use for data storage (e.g., `Array` for CPU, `CuArray` for GPU).
+- `backend = CPU()`: The KernelAbstractions backend to use (e.g., `CPU()` for CPU, `CUDABackend()` for GPU).
 - `gamma::Real = 1.0`: Relativistic gamma factor of the beam.
 - `total_charge::Real = 0.0`: Total charge of the particle bunch.
 
@@ -206,7 +198,7 @@ function Mesh3D(
     min_bounds::NTuple{3, Real},
     max_bounds::NTuple{3, Real};
     T::Type{<:AbstractFloat}=Float64,
-    array_type::Type{<:AbstractArray}=Array,
+    backend=CPU(),
     gamma::Real=1.0,
     total_charge::Real=0.0
 )
@@ -228,18 +220,11 @@ function Mesh3D(
     delta = (cv_max_bounds .- cv_min_bounds) ./ (grid_size .- 1)
 
     # --- Array Allocation ---
-    # Create arrays on the CPU first
-    rho_cpu = zeros(T, grid_size)
-    efield_cpu = zeros(T, (grid_size..., 3))
-
-    # Move arrays to the target device (e.g., GPU)
-    rho = adapt(array_type, rho_cpu)
-    efield = adapt(array_type, efield_cpu)
+    rho = KernelAbstractions.zeros(backend, T, grid_size...)
+    efield = KernelAbstractions.zeros(backend, T, grid_size..., 3)
 
     # --- Struct Instantiation ---
-    A = typeof(rho) # Get the concrete array type
-    B = typeof(efield)
-    return Mesh3D{T, A, B}(
+    return Mesh3D{T, typeof(rho), typeof(efield)}(
         grid_size,
         cv_min_bounds,
         cv_max_bounds,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,17 @@
 using SpaceCharge
 using Test
-using CUDA
 using KernelAbstractions
 using FFTW
+
+# Conditionally load CUDA for GPU tests
+# Note: CUDA is not a required test dependency. To run GPU tests, install CUDA manually:
+#   using Pkg; Pkg.add("CUDA")
+const CUDA_AVAILABLE = try
+    using CUDA
+    CUDA.functional()
+catch
+    false
+end
 
 # Include individual test modules
 include("test_mesh.jl")
@@ -20,8 +29,10 @@ include("test_gpu.jl")
     run_interpolation_tests()
     
     # GPU tests only if CUDA is available
-    if CUDA.functional()
+    if CUDA_AVAILABLE
         run_gpu_tests()
+    else
+        @info "CUDA not available, skipping GPU tests"
     end
 end
 

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -13,7 +13,7 @@ function run_gpu_tests()
             particles_q = [1.0]
             
             mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; 
-                             T=Float32, array_type=CuArray)
+                             T=Float32, backend=CUDABackend())
             
             @test eltype(mesh_gpu.rho) == Float32
             @test mesh_gpu.rho isa CuArray{Float32, 3}
@@ -29,7 +29,7 @@ function run_gpu_tests()
             particles_q_gpu = CuArray([1.0f0])
             
             mesh_gpu = Mesh3D(grid_size, Array(particles_x_gpu), Array(particles_y_gpu), Array(particles_z_gpu); 
-                             T=Float32, array_type=CuArray)
+                             T=Float32, backend=CUDABackend())
             
             deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)
             
@@ -49,7 +49,7 @@ function run_gpu_tests()
             particles_q_gpu = CuArray([1.0f0])
             
             mesh_gpu = Mesh3D(grid_size, Array(particles_x_gpu), Array(particles_y_gpu), Array(particles_z_gpu); 
-                             T=Float32, array_type=CuArray)
+                             T=Float32, backend=CUDABackend())
             
             # Set up a simple field pattern (use broadcasting to avoid scalar indexing)
             efield_cpu = zeros(Float32, (6,6,6,3))
@@ -79,7 +79,7 @@ function run_gpu_tests()
             particles_q_gpu = CuArray([1.0f0])
             
             mesh_gpu = Mesh3D(grid_size, Array(particles_x_gpu), Array(particles_y_gpu), Array(particles_z_gpu); 
-                             T=Float32, array_type=CuArray, gamma=2.0)
+                             T=Float32, backend=CUDABackend(), gamma=2.0)
             
             # Deposit charge and solve
             deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)
@@ -101,7 +101,7 @@ function run_gpu_tests()
             particles_q_gpu = CuArray([1.0f0, -1.0f0])
             
             mesh_gpu = Mesh3D(grid_size, Array(particles_x_gpu), Array(particles_y_gpu), Array(particles_z_gpu); 
-                             T=Float32, array_type=CuArray)
+                             T=Float32, backend=CUDABackend())
             
             # Deposit and solve
             deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)
@@ -139,7 +139,7 @@ function run_gpu_tests()
             particles_z_gpu = CuArray(Float32.(particles_z))
             particles_q_gpu = CuArray(Float32.(particles_q))
             
-            mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; T=Float32, array_type=CuArray)
+            mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; T=Float32, backend=CUDABackend())
             deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)
             solve!(mesh_gpu)
             
@@ -157,7 +157,7 @@ function run_gpu_tests()
             particles_q_gpu = CuArray([1.0f0])
             
             mesh_gpu = Mesh3D(grid_size, Array(particles_x_gpu), Array(particles_y_gpu), Array(particles_z_gpu); 
-                             T=Float32, array_type=CuArray)
+                             T=Float32, backend=CUDABackend())
             
             # Deposit some charge
             deposit!(mesh_gpu, particles_x_gpu, particles_y_gpu, particles_z_gpu, particles_q_gpu)

--- a/test/test_mesh.jl
+++ b/test/test_mesh.jl
@@ -65,7 +65,7 @@ function run_mesh_tests()
             
             if CUDA.functional()
                 mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; 
-                                 T=Float32, array_type=CuArray)
+                                 T=Float32, backend=CUDABackend())
                 @test eltype(mesh_gpu.rho) == Float32
                 @test mesh_gpu.rho isa CuArray{Float32, 3}
                 @test mesh_gpu.efield isa CuArray{Float32, 4}

--- a/test/test_mesh.jl
+++ b/test/test_mesh.jl
@@ -63,8 +63,8 @@ function run_mesh_tests()
             @test eltype(mesh_float32.rho) == Float32
             @test eltype(mesh_float32.efield) == Float32
             
-            if CUDA.functional()
-                mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z; 
+            if CUDA_AVAILABLE
+                mesh_gpu = Mesh3D(grid_size, particles_x, particles_y, particles_z;
                                  T=Float32, backend=CUDABackend())
                 @test eltype(mesh_gpu.rho) == Float32
                 @test mesh_gpu.rho isa CuArray{Float32, 3}


### PR DESCRIPTION
This PR addresses two issues #8 and #9. 

## Summary

  - Remove Adapt.jl and CUDA.jl as package dependencies for lightweight installation
  - Replace `array_type=CuArray` parameter with `backend=CUDABackend()` for explicit backend specification
  - Add automatic backend inference from particle arrays (CuArray particles → CUDABackend)
  - Make GPU tests optional (run only when CUDA is available)
  - Update all examples, benchmarks, and tests to use the new backend API

## Breaking Changes
Users currently using `array_type=CuArray` must update to `backend=CUDABackend()`. However, users with CuArray particles can omit the backend parameter entirely for automatic inference.

Migration example:
```julia
# Old API
mesh = Mesh3D(grid_size, particles_x, particles_y, particles_z; array_type=CuArray)

# New API - Option 1: Automatic inference (recommended)
particles_x_gpu = CuArray(particles_x)
mesh = Mesh3D(grid_size, particles_x_gpu, particles_y_gpu, particles_z_gpu)

# New API - Option 2: Explicit backend
mesh = Mesh3D(grid_size, particles_x, particles_y, particles_z; backend=CUDABackend())